### PR TITLE
Fix DB connection cleanup

### DIFF
--- a/irc_client/backend/database.py
+++ b/irc_client/backend/database.py
@@ -39,6 +39,7 @@ class DatabaseManager:
         
     def _create_tables(self):
         """Creates required database tables if they don't exist."""
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
@@ -98,6 +99,7 @@ class DatabaseManager:
             
         Returns:
             True if successful, False otherwise
+        conn = None
         """
         try:
             conn = sqlite3.connect(self.db_path)
@@ -141,6 +143,7 @@ class DatabaseManager:
         Returns:
             True if successful, False otherwise
         """
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
@@ -187,6 +190,7 @@ class DatabaseManager:
             List of server info dictionaries
         """
         servers = []
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             conn.row_factory = sqlite3.Row
@@ -227,6 +231,7 @@ class DatabaseManager:
             List of channel info dictionaries
         """
         channels = []
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             conn.row_factory = sqlite3.Row
@@ -264,6 +269,7 @@ class DatabaseManager:
         Returns:
             True if successful, False otherwise
         """
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
@@ -290,6 +296,7 @@ class DatabaseManager:
         Returns:
             True if successful, False otherwise
         """
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
@@ -325,6 +332,7 @@ class DatabaseManager:
         Returns:
             True if successful, False otherwise
         """
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()
@@ -364,6 +372,7 @@ class DatabaseManager:
         Returns:
             Setting value or default_value if not found
         """
+        conn = None
         try:
             conn = sqlite3.connect(self.db_path)
             cursor = conn.cursor()


### PR DESCRIPTION
## Summary
- ensure SQLite connections are always defined before cleanup

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841b683fedc83228373f859c6b0c378