### PR TITLE
Fix typo in Main.qml comment

### DIFF
--- a/irc_client/ui/qml/Main.qml
+++ b/irc_client/ui/qml/Main.qml
@@ -11,7 +11,7 @@ ApplicationWindow {
     width: 1024
     height: 768
     title: qsTr("TesseractIRC")
-    color: "#17212b"  // Dark backgroun
+    color: "#17212b"  // Dark background
     
     // Minimum window size
     minimumWidth: 800


### PR DESCRIPTION
## Summary
- correct 'backgroun' typo in Main.qml

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6841b8f5047c83229b35e8ab2716e8df